### PR TITLE
Dev

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Lim",
+      "request": "launch",
+      "type": "dart",
+      "program": "example/lim_example.dart"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.1
+
+- Added limits micro and millisceonds since epoch
+- Added max charcode for BMP
+- Fixed an issue with the lowest possible date
+- Removed dev dependency on the intl package
+
 ## 0.1.0
 
 - Initial version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.1.1
 
-- Added limits micro and millisceonds since epoch
-- Added max charcode for BMP
+- Added limits for micro and milliseconds since the epoch
+- Added max char code for the Basic Multilingual Plane
 - Fixed an issue with the lowest possible date
 - Removed dev dependency on the intl package
 

--- a/example/lim_example.dart
+++ b/example/lim_example.dart
@@ -2,14 +2,17 @@ import 'package:lim/lim.dart';
 
 void main() {
   print('''
-    Byte:      <${Lim.minByte}>..<${Lim.maxByte.toRadixString(0x10).toUpperCase()}>
-    CharCode:  <${Lim.minCharCode}>..<${Lim.maxCharCode.toRadixString(0x10).toUpperCase()}>
     MaxAscii:  <${Lim.maxCharCodeAscii.toRadixString(0x10).toUpperCase()}>
     MaxLatin1: <${Lim.maxCharCodeLatin1.toRadixString(0x10).toUpperCase()}>
+    MaxBmp:    <${Lim.maxCharCodeBmp.toRadixString(0x10).toUpperCase()}>
+    Byte:      <${Lim.minByte}>..<${Lim.maxByte.toRadixString(0x10).toUpperCase()}>
+    CharCode:  <${Lim.minCharCode}>..<${Lim.maxCharCode.toRadixString(0x10).toUpperCase()}>
     Double:    <${Lim.minDouble}>..<${Lim.maxDoubleNegative}>,0,<${Lim.minDoublePositive}>..<${Lim.maxDouble}>
     Num:       <${Lim.minNum}>..<${Lim.maxNumNegative}>,0,<${Lim.minNumPositive}>..<${Lim.maxNum}>
     Int:       <${Lim.minInt}>..<${Lim.maxInt}>
     DateTime:  <${Lim.minDateTime}>..<${Lim.maxDateTime}>
+    Mcs:       <${Lim.minMicrosecondsSinceEpoch}>..<${Lim.maxMicrosecondsSinceEpoch}>
+    McsSafe:   <${Lim.minMicrosecondsSinceEpochSafe}>..<${Lim.maxMicrosecondsSinceEpochSafe}>
   '''
       .replaceAll(RegExp(r'^\s+', multiLine: true), ''));
 }

--- a/lib/src/lim_base.dart
+++ b/lib/src/lim_base.dart
@@ -12,15 +12,19 @@ class Lim {
   ///
   static final minByte = 0;
 
-  /// Highest character code (Unicode)
+  /// Highest character code for the Unicode set
   ///
   static final maxCharCode = 0x10FFFF;
 
-  /// Highest character code for ASCII (7-bit)
+  /// Highest character code for the ASCII set (7-bit)
   ///
   static final maxCharCodeAscii = 0x7F;
 
-  /// Highest character code for Latin-1 (8-bit)
+  /// Highest character code for the Basic Multilingual Plane (16-bit)
+  ///
+  static final maxCharCodeBmp = 0xFFFF;
+
+  /// Highest character code for the Latin-1 set (8-bit)
   ///
   static final maxCharCodeLatin1 = maxByte;
 
@@ -30,19 +34,19 @@ class Lim {
 
   /// Highest date/time
   ///
-  static final maxDateTime = DateTime(275760, 09, 13);
+  static final maxDateTime = DateTime.fromMicrosecondsSinceEpoch(maxMicrosecondsSinceEpoch);
 
-  /// Highest safe date/time (max - 1d to allow timezone conversions)
+  /// Variation of [maxDateTime] capable of TZ conversions
   ///
-  static final maxDateTimeSafe = maxDateTime.add(Duration(days: -1));
+  static final maxDateTimeSafe = DateTime.fromMicrosecondsSinceEpoch(maxMicrosecondsSinceEpochSafe);
 
-  /// Lowest date/time (.year fails on values lower than this)
+  /// Lowest date/time
   ///
-  static final minDateTime = DateTime(-271821, 4, 21);
+  static final minDateTime = DateTime.fromMicrosecondsSinceEpoch(minMicrosecondsSinceEpoch);
 
-  /// Lowest safe date/time (min + 1d to allow timezone conversions)
+  /// Variation of [minDateTime] capable of TZ conversions
   ///
-  static final minDateTimeSafe = minDateTime.add(Duration(days: 1));
+  static final minDateTimeSafe = DateTime.fromMicrosecondsSinceEpoch(minMicrosecondsSinceEpochSafe);
 
   /// Highest double
   ///
@@ -60,13 +64,45 @@ class Lim {
   ///
   static const minDoublePositive = 5e-324;
 
-  /// Highest integer
+  /// Highest portable integer
   ///
   static const maxInt = 9007199254740991;
 
-  /// Lowest integer
+  /// Lowest portable integer
   ///
   static const minInt = -9007199254740992;
+
+  /// Highest number of microseconds representing a date/time value
+  ///
+  static const maxMicrosecondsSinceEpoch = (Duration.microsecondsPerDay * 100 * 1000 * 1000);
+
+  /// Variation of [maxMicrosecondsSinceEpoch] capable of TZ conversions
+  ///
+  static const maxMicrosecondsSinceEpochSafe = (maxMicrosecondsSinceEpoch - Duration.microsecondsPerDay);
+
+  /// Lowest number of microseconds representing a date/time value
+  ///
+  static const minMicrosecondsSinceEpoch = -maxMicrosecondsSinceEpoch;
+
+  /// Variation of [minMicrosecondsSinceEpoch] capable of TZ conversions
+  ///
+  static const minMicrosecondsSinceEpochSafe = (minMicrosecondsSinceEpoch + Duration.microsecondsPerDay);
+
+  /// Highest number of milliseconds representing a date/time value
+  ///
+  static const maxMillisecondsSinceEpoch = (maxMicrosecondsSinceEpoch ~/ 1000);
+
+  /// Variation of [maxMillisecondsSinceEpoch] capable of TZ conversions
+  ///
+  static const maxMillisecondsSinceEpochSafe = (maxMicrosecondsSinceEpochSafe ~/ 1000);
+
+  /// Lowest number of milliseconds representing a date/time value
+  ///
+  static const minMillisecondsSinceEpoch = (minMicrosecondsSinceEpoch ~/ 1000);
+
+  /// Variation of [minMillisecondsSinceEpoch] capable of TZ conversions
+  ///
+  static const minMillisecondsSinceEpochSafe = (minMicrosecondsSinceEpochSafe ~/ 1000);
 
   /// Highest numeric (same as double)
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lim
 description: A set of maximum and minimum constant values for Dart datatypes and character codes.
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/aiurovet/lim/
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,4 +9,3 @@ environment:
 dev_dependencies:
   lints: ^1.0.0
   test: ^1.16.0
-  intl: ^0.17.0

--- a/test/lim_test.dart
+++ b/test/lim_test.dart
@@ -2,15 +2,14 @@
 // All rights reserved under MIT license (see LICENSE file)
 
 import 'package:lim/lim.dart';
-import 'package:intl/intl.dart';
 import 'package:test/test.dart';
 
 /// Unit tests for all Lim constants
 ///
 void main() {
-  final prefix = 'Lim -';
+  final p = 'Lim -';
 
-  group('$prefix Byte -', () {
+  group('$p Byte -', () {
     test('max', () {
       expect(Lim.maxByte.toString(), '255');
     });
@@ -18,7 +17,7 @@ void main() {
       expect(Lim.minByte.toString(), '0');
     });
   });
-  group('$prefix Char Code -', () {
+  group('$p Char Code -', () {
     test('last character', () {
       expect(String.fromCharCode(Lim.maxCharCode), '􏿿');
     });
@@ -28,6 +27,9 @@ void main() {
     test('highest ASCII', () {
       expect(Lim.maxCharCodeAscii.toRadixString(0x10).toLowerCase(), '7f');
     });
+    test('highest BMP', () {
+      expect(Lim.maxCharCodeBmp.toRadixString(0x10).toLowerCase(), 'ffff');
+    });
     test('highest Latin1', () {
       expect(Lim.maxCharCodeLatin1.toRadixString(0x10).toLowerCase(), 'ff');
     });
@@ -35,23 +37,29 @@ void main() {
       expect(Lim.minCharCode.toRadixString(0x10).toLowerCase(), '0');
     });
   });
-  group('$prefix DateTime -', () {
-    final f = DateFormat('y-MM-dd');
+  group('$p DateTime -', () {
     test('max', () {
       expect(Lim.maxDateTime.year, 275760);
-      expect(f.format(Lim.maxDateTime), '275760-09-13');
+      expect(Lim.maxDateTime.month, 9);
+      expect(Lim.maxDateTime.day, 13);
     });
     test('max safe', () {
-      expect(f.format(Lim.maxDateTimeSafe), '275760-09-12');
+      expect(Lim.maxDateTimeSafe.year, 275760);
+      expect(Lim.maxDateTimeSafe.month, 9);
+      expect(Lim.maxDateTimeSafe.day, 12);
     });
     test('min safe', () {
-      expect(Lim.minDateTimeSafe.day, 22);
+      expect(Lim.minDateTimeSafe.year, -271821);
+      expect(Lim.minDateTimeSafe.month, 4);
+      expect(Lim.minDateTimeSafe.day, 21);
     });
     test('min', () {
       expect(Lim.minDateTime.year, -271821);
+      expect(Lim.minDateTime.month, 4);
+      expect(Lim.minDateTime.day, 20);
     });
   });
-  group('$prefix Double -', () {
+  group('$p Double -', () {
     test('max', () {
       expect(Lim.maxDouble.toString(), '1.7976931348623157e+308');
     });
@@ -65,7 +73,7 @@ void main() {
       expect(Lim.minDoublePositive.toString(), '5e-324');
     });
   });
-  group('$prefix Int -', () {
+  group('$p Int -', () {
     test('max', () {
       expect(Lim.maxInt.toString(), '9007199254740991');
     });
@@ -73,7 +81,7 @@ void main() {
       expect(Lim.minInt.toString(), '-9007199254740992');
     });
   });
-  group('$prefix Num -', () {
+  group('$p Num -', () {
     test('max', () {
       expect(Lim.maxNum, Lim.maxDouble);
     });


### PR DESCRIPTION
Added limits for micro and milliseconds since the epoch, max char code for BMP, fixed an issue with the lowest possible date and removed dev dependency on the intl package.